### PR TITLE
Refactoring time service and increasing test coverage

### DIFF
--- a/service_time/app/no/uio/musit/microservice/time/domain/Time.scala
+++ b/service_time/app/no/uio/musit/microservice/time/domain/Time.scala
@@ -22,19 +22,17 @@ import org.joda.time.format.DateTimeFormat
 import org.joda.time.{LocalDate, LocalTime}
 import play.api.libs.json._
 
-
-
-abstract class MusitTime
+sealed trait MusitTime
 
 case class Time(time:LocalTime) extends MusitTime
 case class Date(date:LocalDate) extends MusitTime
 case class DateTime(date:Date, time:Time) extends MusitTime
 
-abstract class MusitJodaFilter
+sealed trait MusitJodaFilter
 
-case class MusitDateFilter() extends MusitJodaFilter
-case class MusitTimeFilter() extends MusitJodaFilter
-case class MusitDateTimeFilter() extends MusitJodaFilter
+object MusitDateFilter extends MusitJodaFilter
+object MusitTimeFilter extends MusitJodaFilter
+object MusitDateTimeFilter extends MusitJodaFilter
 
 object DateFormatDefinition {
   val dateFormat:String = "yyyy-MM-dd"

--- a/service_time/app/no/uio/musit/microservice/time/resource/TimeResource_V1.scala
+++ b/service_time/app/no/uio/musit/microservice/time/resource/TimeResource_V1.scala
@@ -18,7 +18,6 @@
  */
 package no.uio.musit.microservice.time.resource
 
-import no.uio.musit.microservice.time.domain._
 import no.uio.musit.microservice.time.service.TimeService
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -27,26 +26,11 @@ import scala.concurrent.Future
 
 class TimeResource_V1 extends Controller with TimeService {
 
-
-
-  def actionGetNow = Action.async { request =>
-    var filter:Option[MusitJodaFilter] = None
-
-    val filterString:String = request.getQueryString("filter").orNull
-
-    if (filterString != null && filterString.size > 0) {
-      val list = "(date|time)".r.findAllIn(filterString).toList.sorted
-
-
-        list match {
-          case List ("date","time") => filter= Some( new MusitDateTimeFilter)
-          case List ("time")        => filter= Some( new MusitTimeFilter)
-          case List ("date")        => filter= Some( new MusitDateFilter)
-          case                              _ => throw new IllegalArgumentException("Only supports empty filter or filter on time, date or time and date")
-        }
+  def actionGetNow = Action.async {
+    _.getQueryString("filter").map(filter => getNow(getMusitFilter(filter))) match {
+      case Some(date) => Future.successful(Ok(Json.toJson(date)))
+      case _ => Future.successful(BadRequest("Missing filter in query string"))
     }
-    val now = getNow(filter)
-    Future.successful(Ok(Json.toJson(now)))
   }
 
 }

--- a/service_time/test/TimeResourceSpec.scala
+++ b/service_time/test/TimeResourceSpec.scala
@@ -31,5 +31,15 @@ class TimeResourceSpec extends PlaySpecification {
       val result = await(futureResult)
       result.header.status must equalTo(BAD_REQUEST)
     }
+
+    "give BadRequest when provided invalid filter" in {
+      try {
+        val futureResult = new TimeResource_V1().actionGetNow(FakeRequest("GET", "someurl?filter=uglepose"))
+        val result = await(futureResult)
+        throw new IllegalStateException("Should not occur")
+      } catch {
+        case e: IllegalArgumentException => e.getLocalizedMessage.must(equalTo("Only supports empty filter or filter on time, date or time and date"))
+      }
+    }
   }
 }

--- a/service_time/test/TimeResourceSpec.scala
+++ b/service_time/test/TimeResourceSpec.scala
@@ -1,0 +1,35 @@
+import no.uio.musit.microservice.time.resource.TimeResource_V1
+import play.api.test.{FakeRequest, PlaySpecification}
+
+import scala.util.{Failure, Success}
+import play.test.Helpers._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class TimeResourceSpec extends PlaySpecification {
+  "TimeResource controller" should {
+    "give OK when provided a datetime filter" in {
+      val futureResult = new TimeResource_V1().actionGetNow(FakeRequest("GET", "someurl?filter=datetime"))
+      val result = await(futureResult)
+      result.header.status must equalTo(OK)
+    }
+
+    "give OK when provided a date filter" in {
+      val futureResult = new TimeResource_V1().actionGetNow(FakeRequest("GET", "someurl?filter=date"))
+      val result = await(futureResult)
+      result.header.status must equalTo(OK)
+    }
+
+    "give OK when provided a time filter" in {
+      val futureResult = new TimeResource_V1().actionGetNow(FakeRequest("GET", "someurl?filter=time"))
+      val result = await(futureResult)
+      result.header.status must equalTo(OK)
+    }
+
+    "give BadRequest when provided no filter" in {
+      val futureResult = new TimeResource_V1().actionGetNow(FakeRequest("GET", "someurl"))
+      val result = await(futureResult)
+      result.header.status must equalTo(BAD_REQUEST)
+    }
+  }
+}

--- a/service_time/test/TimeUnitTest.scala
+++ b/service_time/test/TimeUnitTest.scala
@@ -10,9 +10,67 @@ class TimeUnitTest extends PlaySpec with TimeService {
 
   "Testing TimeService" must {
 
+    "get musit datetime filter" in {
+      val filter = getMusitFilter("datetime")
+      assert(filter.isDefined)
+      assert(filter.get == MusitDateTimeFilter)
+    }
+
+    "get musit date filter" in {
+      val filter = getMusitFilter("date")
+      assert(filter.isDefined)
+      assert(filter.get == MusitDateFilter)
+    }
+
+    "get musit time filter" in {
+      val filter = getMusitFilter("time")
+      assert(filter.isDefined)
+      assert(filter.get == MusitTimeFilter)
+    }
+
+    "get musit null filter" in {
+      // FIXME this is silly, really, but shows that the method is resilient. Should be removed when we agree to stop passing around nulls
+      val filter = getMusitFilter(null)
+      assert(filter.isEmpty)
+    }
+
+    "get musit bad filter" in {
+      val thrown = intercept[IllegalArgumentException] {
+        getMusitFilter("uglepose")
+      }
+      assert(thrown != null)
+    }
+
+    "get sorted datetime filters" in {
+      val sortedFilters = getSortedFilters("datetime")
+      assert(sortedFilters != null)
+      assert(sortedFilters.length == 2)
+      assert(sortedFilters.head == "date")
+      assert(sortedFilters.last == "time")
+    }
+
+    "get sorted date filters" in {
+      val sortedFilters = getSortedFilters("date")
+      assert(sortedFilters != null)
+      assert(sortedFilters.length == 1)
+      assert(sortedFilters.head == "date")
+    }
+
+    "get sorted time filters" in {
+      val sortedFilters = getSortedFilters("time")
+      assert(sortedFilters != null)
+      assert(sortedFilters.length == 1)
+      assert(sortedFilters.head == "time")
+    }
+
+    "get sorted null filters" in {
+      val sortedFilters = getSortedFilters(null)
+      assert(sortedFilters != null)
+      assert(sortedFilters.length == 0)
+    }
 
     "get now Date" in {
-      val now = getNow(Some(MusitDateFilter()))
+      val now = getNow(Some(MusitDateFilter))
       assert(now.isInstanceOf[Date])
       assert(now.asInstanceOf[Date].date != null)
     }
@@ -25,41 +83,17 @@ class TimeUnitTest extends PlaySpec with TimeService {
     }
 
     "get now DateTime" in {
-      val now = getNow(Some(MusitDateTimeFilter()))
+      val now = getNow(Some(MusitDateTimeFilter))
       assert(now.isInstanceOf[DateTime])
       assert(now.asInstanceOf[DateTime].date != null)
       assert(now.asInstanceOf[DateTime].time != null)
     }
 
-
     "get now Time" in {
-      val now = getNow(Some(MusitTimeFilter()))
+      val now = getNow(Some(MusitTimeFilter))
       assert(now.isInstanceOf[Time])
       assert(now.asInstanceOf[Time].time != null)
     }
-
-    "get now Some(null)" in {
-      val thrown = intercept[IllegalArgumentException] {
-        val now = getNow(Some(null))
-        assert(now.isInstanceOf[DateTime])
-        assert(now.asInstanceOf[DateTime].date != null)
-        assert(now.asInstanceOf[DateTime].time != null)
-      }
-      assert(thrown != null)
-    }
-
-    "get now null" in {
-      val thrown = intercept[IllegalArgumentException] {
-        val now = getNow(null)
-        assert(now.isInstanceOf[DateTime])
-        assert(now.asInstanceOf[DateTime].date != null)
-        assert(now.asInstanceOf[DateTime].time != null)
-      }
-      assert(thrown != null)
-    }
-
-
-
   }
 
 }


### PR DESCRIPTION
1. Moved all business logic from controller to service
   - Easier to test individual parts of the business logic
2. MusitJodaFilter and MusitTime is now sealed traits
   - Compiler will now nag if matching on those types does not include all implementations
3. Adding tests for controller and service with test coverage now on 87%

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/musit-norway/musit/19)

<!-- Reviewable:end -->
