### PR TITLE
Fixing stacktrace in console output due to missing dependency in common.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,14 +54,25 @@ val noPublish = Seq(
   publishLocal := {}
 )
 
-lazy val root = project in file(".") settings noPublish aggregate(common_test, common, security, service_core, service_musit_thing, service_actor, service_geo_location, service_time,
-  service_storage_admin, service_event)
+lazy val root = project in file(".") settings noPublish aggregate(
+  common_test,
+  common,
+  security,
+  service_core,
+  service_musit_thing,
+  service_actor,
+  service_geo_location,
+  service_time,
+  service_storage_admin,
+  service_event
+)
 
 // Base projects used as dependencies
 lazy val common = (
   BaseProject("common")
     settings noPublish
     settings(libraryDependencies ++= testablePlayWithPersistenceDependencies)
+    settings(libraryDependencies += PlayFrameWork.logback)
     settings(scoverageSettings: _*)
   ) dependsOn(common_test % "it,test")
 

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    
+
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -10,7 +10,7 @@
 
   <include resource="local-logback.xml"/>
 
-  <appender name="SLACK" class="no.uio.musit.microservices.common.log.SlackLogbackAppender">
+  <!--appender name="SLACK" class="no.uio.musit.microservices.common.log.SlackLogbackAppender">
     <webhook>https://hooks.slack.com/services/${musit.slack.systemHookKey}</webhook>
     <host>${HOSTNAME}</host>
     <service>${applicationName}</service>
@@ -21,7 +21,7 @@
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>ERROR</level>
     </filter>
-  </appender>
+  </appender-->
 
   <!--
     The logger name is typically the Java/Scala package name.
@@ -32,7 +32,7 @@
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />
-    <appender-ref ref="ASYNC_SLACK" />
+    <!--appender-ref ref="ASYNC_SLACK" /-->
   </root>
 
 </configuration>

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -35,6 +35,7 @@ object CommonSettings {
       "-deprecation", // Emit warning and location for usages of deprecated APIs.
       "-feature", // Emit warning and location for usages of features that should be imported explicitly.
       "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+      // FIXME: the fatal-warnings option must be re-enabled at some point!
     //  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
       "-Xlint", // Enable recommended additional warnings.
       "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver.
@@ -43,7 +44,6 @@ object CommonSettings {
       "-Ywarn-nullary-override", // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
       "-Ywarn-numeric-widen", // Warn when numerics are widened.
       // For advanced language features
-      //"-Ydependent-method-types",
       "-language:implicitConversions",
       "-language:higherKinds",
       "-language:existentials",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val cache = "com.typesafe.play" %% "play-cache" % version
     val ws = "com.typesafe.play" %% "play-ws" % version
     val json = "com.typesafe.play" %% "play-json" % version
-    val logback = "com.typesafe.play" %% "play-logback" % version % "provided"
+    val logback = "com.typesafe.play" %% "play-logback" % version
 
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,6 +38,7 @@ object Dependencies {
     val cache = "com.typesafe.play" %% "play-cache" % version
     val ws = "com.typesafe.play" %% "play-ws" % version
     val json = "com.typesafe.play" %% "play-json" % version
+    val logback = "com.typesafe.play" %% "play-logback" % version % "provided"
 
   }
 

--- a/service_event/src/it/resources/logback.xml
+++ b/service_event/src/it/resources/logback.xml
@@ -30,7 +30,7 @@
 
     <logger name="ch.qos.logback" level="ERROR"/>
     <logger name="logger" level="ERROR"/>
-    <logger name="slick.jdbc" level="DEBUG"/>
+    <logger name="slick.jdbc" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/service_event/src/test/scala/BaseEventDTOTest.scala
+++ b/service_event/src/test/scala/BaseEventDTOTest.scala
@@ -9,8 +9,7 @@ class BaseEventDTOTest extends PlaySpec {
     val date = new java.util.Date()
     val timestamp = new java.sql.Timestamp(date.getTime)
 
-    BaseEventDto(None, None, null, None, Seq.empty, Seq.empty, Seq.empty, None, Seq.empty, None, valueLong = value, None, None, Some("nobody"), Some(timestamp)
-    )
+    BaseEventDto(None, None, null, None, Seq.empty, Seq.empty, Seq.empty, None, Seq.empty, None, valueLong = value, None, None, Some("nobody"), Some(timestamp))
   }
 
   "getOptBool" must {

--- a/service_storage_admin/src/it/resources/logback.xml
+++ b/service_storage_admin/src/it/resources/logback.xml
@@ -10,7 +10,7 @@
 
     <logger name="ch.qos.logback" level="ERROR"/>
     <logger name="logger" level="ERROR"/>
-    <logger name="slick.jdbc" level="DEBUG"/>
+    <logger name="slick.jdbc" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
The common module did not include a dependency to `play-logging`. This caused the ugly stack trace in the console every time you ran a build/tests.
Also changed log-level of slick jdbc from DEBUG to WARN in tests to reduce verbosity. If you want that verbosity back , you should change the appropriate logback.xml locally. And not include the change in any commit.

Also did some other minor cleanup in the build scripts.
BaseEventDTOTest.scala seemed not have been formatted by scalariform before it was pushed at some point.
