### PR TITLE
MUSARK-749

### DIFF
--- a/musit-models/src/main/scala/no/uio/musit/models/Email.scala
+++ b/musit-models/src/main/scala/no/uio/musit/models/Email.scala
@@ -23,7 +23,11 @@ import play.api.data.validation._
 import play.api.libs.json._
 import play.api.libs.json.Reads._
 
-case class Email(value: String) extends AnyVal
+case class Email(value: String) extends AnyVal {
+
+  def startsWith(str: String): Boolean = value.startsWith(str)
+
+}
 
 object Email {
 

--- a/service_actor/conf/logback.xml
+++ b/service_actor/conf/logback.xml
@@ -35,10 +35,10 @@
   <logger name="slick.jdbc" level="WARN"/>
 
   <logger name="no.uio.musit" level="INFO"/>
-  <logger name="controllers" level="INFO"/>
-  <logger name="services" level="INFO"/>
+  <logger name="controllers" level="DEBUG"/>
+  <logger name="services" level="DEBUG"/>
   <logger name="models" level="INFO"/>
-  <logger name="repositories" level="INFO"/>
+  <logger name="repositories" level="DEBUG"/>
   <logger name="accesslog" level="INFO"/>
 
   <root level="ERROR">

--- a/service_actor/test/services/ActorServiceSpec.scala
+++ b/service_actor/test/services/ActorServiceSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * MUSIT is a museum database to archive natural and cultural history data.
+ * Copyright (C) 2016  MUSIT Norway, part of www.uio.no (University of Oslo)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package services
+
+import models.Person
+import no.uio.musit.models.{ActorId, DatabaseId, Email}
+import no.uio.musit.security.UserInfo
+import no.uio.musit.test.MusitSpecWithAppPerSuite
+
+class ActorServiceSpec extends MusitSpecWithAppPerSuite {
+
+  val service = fromInstanceCache[ActorService]
+
+  def generatePersonSeq: Seq[Person] = {
+    (0 until 15).map { i =>
+      Person(
+        id = DatabaseId.fromOptLong(Some(i.toLong)),
+        fn = s"Full $i Name",
+        dataportenUser = Some(s"${i}user"),
+        applicationId = ActorId.generateAsOpt()
+      )
+    }
+  }
+
+  def generateUserInfos: Seq[UserInfo] = {
+    Seq(4, 7, 11).map { i =>
+      UserInfo(
+        id = ActorId.generate(),
+        secondaryIds = Some(Seq(s"${i}user@foo.io")),
+        name = Some(s"Full $i Name"),
+        email = Some(Email(s"user$i@bar.foo.io")),
+        picture = None
+      )
+    }
+  }
+
+  "The ActorService" should {
+
+    "merge duplicate entries in a Person list into a list of UserInfo" in {
+      val persons = generatePersonSeq
+      val users = generateUserInfos
+
+      val res = service.merge(users, persons).sortBy { p =>
+        p.dataportenUser.map(_.dropRight(4).toInt)
+      }
+
+      res.size mustBe 15
+
+      res(4).applicationId mustBe persons(4).applicationId
+      res(7).applicationId mustBe persons(7).applicationId
+      res(11).applicationId mustBe persons(11).applicationId
+      res(4).dataportenId mustBe users.headOption.map(_.id)
+      res(7).dataportenId mustBe users.tail.headOption.map(_.id)
+      res(11).dataportenId mustBe users.lastOption.map(_.id)
+    }
+
+  }
+
+}

--- a/service_actor/test/services/ActorServiceSpec.scala
+++ b/service_actor/test/services/ActorServiceSpec.scala
@@ -58,7 +58,8 @@ class ActorServiceSpec extends MusitSpecWithAppPerSuite {
       val users = generateUserInfos
 
       val res = service.merge(users, persons).sortBy { p =>
-        p.dataportenUser.map(_.dropRight(4).toInt)
+        // isolate the number part of the ID
+        p.dataportenUser.map(_.stripSuffix("@foo.io").stripSuffix("user").toInt)
       }
 
       res.size mustBe 15

--- a/service_storagefacility/app/models/Move.scala
+++ b/service_storagefacility/app/models/Move.scala
@@ -19,12 +19,11 @@
 
 package models
 
-import no.uio.musit.models.{ActorId, ObjectId, StorageNodeDatabaseId}
+import no.uio.musit.models.{ObjectId, StorageNodeDatabaseId}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class Move[A](
-  doneBy: ActorId,
   destination: StorageNodeDatabaseId,
   items: Seq[A]
 )
@@ -32,15 +31,13 @@ case class Move[A](
 object Move {
 
   implicit val storageNodeIdFormat: Format[Move[StorageNodeDatabaseId]] = (
-    (__ \ "doneBy").format[ActorId] and
     (__ \ "destination").format[StorageNodeDatabaseId] and
     (__ \ "items").format[Seq[StorageNodeDatabaseId]]
-  )((db, snid, items) => Move(db, snid, items), m => (m.doneBy, m.destination, m.items))
+  )((snid, items) => Move(snid, items), m => (m.destination, m.items))
 
   implicit val objectIdFormat: Format[Move[ObjectId]] = (
-    (__ \ "doneBy").format[ActorId] and
     (__ \ "destination").format[StorageNodeDatabaseId] and
     (__ \ "items").format[Seq[ObjectId]]
-  )((db, snid, items) => Move(db, snid, items), m => (m.doneBy, m.destination, m.items))
+  )((snid, items) => Move(snid, items), m => (m.destination, m.items))
 
 }

--- a/service_storagefacility/app/models/event/move/MoveEvents.scala
+++ b/service_storagefacility/app/models/event/move/MoveEvents.scala
@@ -50,7 +50,7 @@ object MoveObject {
       val now = dateTimeNow
       MoveObject(
         id = None,
-        doneBy = Option(cmd.doneBy),
+        doneBy = Option(currUserId),
         doneDate = now,
         affectedThing = Option(objectId),
         registeredBy = Option(currUserId),
@@ -77,20 +77,21 @@ case class MoveNode(
 
 object MoveNode {
 
-  def fromCommand(currUserId: ActorId, cmd: Move[StorageNodeDatabaseId]): Seq[MoveNode] = {
-    cmd.items.map { nodeId =>
-      val now = dateTimeNow
-      MoveNode(
-        id = None,
-        doneBy = Option(cmd.doneBy),
-        doneDate = now,
-        affectedThing = Option(nodeId),
-        registeredBy = Option(currUserId),
-        registeredDate = Option(now),
-        eventType = EventType.fromEventTypeId(MoveNodeType.id),
-        from = None,
-        to = cmd.destination
-      )
-    }
+  def fromCommand(
+    currUserId: ActorId,
+    cmd: Move[StorageNodeDatabaseId]
+  ): Seq[MoveNode] = cmd.items.map { nodeId =>
+    val now = dateTimeNow
+    MoveNode(
+      id = None,
+      doneBy = Option(currUserId),
+      doneDate = now,
+      affectedThing = Option(nodeId),
+      registeredBy = Option(currUserId),
+      registeredDate = Option(now),
+      eventType = EventType.fromEventTypeId(MoveNodeType.id),
+      from = None,
+      to = cmd.destination
+    )
   }
 }

--- a/service_storagefacility/test/controllers/StorageControllerIntegrationSpec.scala
+++ b/service_storagefacility/test/controllers/StorageControllerIntegrationSpec.scala
@@ -721,7 +721,7 @@ class StorageControllerIntegrationSpec extends MusitSpecWithServerPerSuite {
 
         val firstElem = resArr.head
         (firstElem \ "doneDate").as[DateTime].withTimeAtStartOfDay() mustBe today
-        (firstElem \ "doneBy").as[String] mustBe adminId.asString
+        (firstElem \ "doneBy").as[String] mustBe writeId.asString
         (firstElem \ "registeredDate").as[DateTime].withTimeAtStartOfDay() mustBe today
         (firstElem \ "registeredBy").as[String] mustBe writeId.asString
         (firstElem \ "from" \ "path").as[NodePath] mustBe NodePath(",1,3,4,6,")
@@ -731,7 +731,7 @@ class StorageControllerIntegrationSpec extends MusitSpecWithServerPerSuite {
 
         val lastElem = resArr.last
         (lastElem \ "doneDate").as[DateTime].withTimeAtStartOfDay() mustBe today
-        (lastElem \ "doneBy").as[String] mustBe adminId.asString
+        (lastElem \ "doneBy").as[String] mustBe writeId.asString
         (lastElem \ "registeredDate").as[DateTime].withTimeAtStartOfDay() mustBe today
         (lastElem \ "registeredBy").as[String] mustBe writeId.asString
         (lastElem \ "from" \ "path").as[NodePath] mustBe NodePath(",1,3,4,5,")

--- a/service_storagefacility/test/services/StorageNodeServiceSpec.scala
+++ b/service_storagefacility/test/services/StorageNodeServiceSpec.scala
@@ -238,7 +238,6 @@ class StorageNodeServiceSpec extends MusitSpecWithAppPerSuite with NodeGenerator
       val mostChildren = childIds ++ grandChildIds
 
       val move = Move[StorageNodeDatabaseId](
-        doneBy = defaultUserId,
         destination = building2.id.get,
         items = Seq(unit1.id.get)
       )
@@ -414,7 +413,7 @@ class StorageNodeServiceSpec extends MusitSpecWithAppPerSuite with NodeGenerator
       currLoc.get.get.id.get.underlying mustBe 5
       currLoc.get.get.path.toString must include(currLoc.get.get.id.get.underlying.toString)
 
-      val moveObject = Move[ObjectId](aid, StorageNodeDatabaseId(4), Seq(oid))
+      val moveObject = Move[ObjectId](StorageNodeDatabaseId(4), Seq(oid))
       val moveSeq = MoveObject.fromCommand(aid, moveObject)
       service.moveObject(defaultMuseumId, oid, moveSeq.head).futureValue
       val newCurrLoc = service.currentObjectLocation(defaultMuseumId, 2).futureValue
@@ -423,7 +422,7 @@ class StorageNodeServiceSpec extends MusitSpecWithAppPerSuite with NodeGenerator
       newCurrLoc.get.get.path.toString must include(newCurrLoc.get.get.id.get.underlying.toString)
 
       val anotherMid = MuseumId(4)
-      val moveSameObject = Move[ObjectId](aid, StorageNodeDatabaseId(3), Seq(oid))
+      val moveSameObject = Move[ObjectId](StorageNodeDatabaseId(3), Seq(oid))
       val moveSameSeq = MoveObject.fromCommand(aid, moveSameObject)
       service.moveObject(anotherMid, oid, moveSameSeq.head).futureValue
       val sameCurrLoc = service.currentObjectLocation(defaultMuseumId, 2).futureValue


### PR DESCRIPTION
Removes "doneBy" from the move service contract and explicitly sets it to the current user.
Actor "details" service: Instead of removing actors found in both the Actor and UserInfo
tables, the results are now merged, so that a Person can be identified by _either_ the
dataporten UUID _or_ the applicationUUID.