### PR TITLE
MUSARK-819

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -1,4 +1,0 @@
-# Detailed build setup
-
-This directory contains the detailed build setup, do not adjust these
-files unless you are 100% sure what you are doing.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@
 // Sets the SBT log level
 logLevel := Level.Warn
 
-resolvers ++= DefaultOptions.resolvers(snapshot = true)
+resolvers ++= DefaultOptions.resolvers(snapshot = false)
 resolvers += Resolver.typesafeRepo("releases")
 resolvers += Resolver.sonatypeRepo("releases")
 

--- a/service_storagefacility/app/repositories/dao/event/ObservationFromToDao.scala
+++ b/service_storagefacility/app/repositories/dao/event/ObservationFromToDao.scala
@@ -52,8 +52,6 @@ class ObservationFromToDao @Inject() (
    * TODO: Document me!
    */
   def getObservationFromTo(id: EventId): Future[Option[ObservationFromToDto]] =
-    db.run(
-      obsFromToTable.filter(event => event.id === id).result.headOption
-    )
+    db.run(obsFromToTable.filter(event => event.id === id).result.headOption)
 
 }

--- a/service_storagefacility/app/repositories/dao/storage/StorageUnitDao.scala
+++ b/service_storagefacility/app/repositories/dao/storage/StorageUnitDao.scala
@@ -118,6 +118,26 @@ class StorageUnitDao @Inject() (
   }
 
   /**
+   * Fetches the node data for provided database ids
+   *
+   * @param mid
+   * @param ids
+   * @return
+   */
+  def getNodesByIds(
+    mid: MuseumId,
+    ids: Seq[StorageNodeDatabaseId]
+  ): Future[Seq[GenericStorageNode]] = {
+    val query = storageNodeTable.filter { sn =>
+      sn.museumId === mid &&
+        sn.isDeleted === false &&
+        (sn.id inSet ids)
+    }.result
+
+    db.run(query).map(_.map(StorageNodeDto.toGenericStorageNode))
+  }
+
+  /**
    * TODO: Document me!!!
    */
   def getStorageTypesInPath(

--- a/service_storagefacility/test/controllers/StorageControllerIntegrationSpec.scala
+++ b/service_storagefacility/test/controllers/StorageControllerIntegrationSpec.scala
@@ -740,7 +740,7 @@ class StorageControllerIntegrationSpec extends MusitSpecWithServerPerSuite {
         val moveJson = Json.parse(
           s"""{
               |  "doneBy": "${adminId.asString}",
-              |  "destination": 4,
+              |  "destination": 5,
               |  "items": [$id2]
               |}""".stripMargin
         )


### PR DESCRIPTION
Resolves really slow batch insert operation that potentially takes down the database.

Inserts of Move events are now done within the same DB transaction. This increases perofmrnace
quite a lot. But, it takes away some control with regards to handling individual errors on which
move operations failed. But, that is a small price to pay considering the alternative is database deadlocks.