### PR TITLE
MUSARK-819, MUSARK-824

### DIFF
--- a/service_storagefacility/app/models/ObjectsLocation.scala
+++ b/service_storagefacility/app/models/ObjectsLocation.scala
@@ -1,0 +1,32 @@
+/*
+ * MUSIT is a museum database to archive natural and cultural history data.
+ * Copyright (C) 2016  MUSIT Norway, part of www.uio.no (University of Oslo)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License,
+ * or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package models
+
+import models.storage.StorageNode
+import no.uio.musit.models.ObjectId
+import play.api.libs.json.{Json, Writes}
+
+case class ObjectsLocation(node: StorageNode, objectIds: Seq[ObjectId])
+
+object ObjectsLocation {
+
+  implicit val writes: Writes[ObjectsLocation] = Json.writes[ObjectsLocation]
+
+}

--- a/service_storagefacility/conf/routes
+++ b/service_storagefacility/conf/routes
@@ -39,6 +39,7 @@ GET           /v1/museum/:mid/storagenodes/:nodeId/observations/:eventId        
 # ~~~~
 GET           /v1/museum/:mid/storagenodes/objects/:oid/locations               controllers.StorageController.objectLocationHistory(mid: Int, oid: Long, limit: Int ?= 50)
 GET           /v1/museum/:mid/storagenodes/objects/:oid/currentlocation         controllers.StorageController.currentObjectLocation(mid: Int, oid: Long)
+GET           /v1/museum/:mid/storagenodes/objects/currentlocations             controllers.StorageController.currentObjectLocations(mid: Int)
 
 # General endpoints
 ### TODO: Find better name for endpoint


### PR DESCRIPTION
Fixes potential problem with the use of "in" expression in queries. Oracle has a limit of 1000 expressions in expression lists. So we have to ensure that these scenarios are dealt with properly.

Also implementing a new service that returns the current location nodes for a list of objectIds. See the routes file and "currentObjectLocation" method in StorageController.