### PR TITLE
Re-write of service for moving nodes. Correcting timestamp format in logback configs.

### DIFF
--- a/musit-service/src/test/resources/logback-test.xml
+++ b/musit-service/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %level - %logger{15} - [%d{yyyy-MM-dd HH:mm:ss.SSS}] - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [musit-service] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/musit-service/src/test/resources/logback-test.xml
+++ b/musit-service/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %level - %logger{15} - [%d{yyyy-MM-dd_HH:mm:ss.SSS}] - %message%n%xException
+        %level - %logger{15} - [%d{yyyy-MM-dd HH:mm:ss.SSS}] - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_actor/conf/logback.xml
+++ b/service_actor/conf/logback.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [actor] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [actor] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>
@@ -38,7 +38,7 @@
     <file>logs/service-actor.log</file>
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [actor] [%level] - %logger - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [actor] [%level] - %logger - %message%n%xException
       </pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/service_actor/test/resources/logback-test.xml
+++ b/service_actor/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [actor] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [actor] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_auth/conf/logback.xml
+++ b/service_auth/conf/logback.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [auth] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [auth] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>
@@ -38,7 +38,7 @@
     <file>logs/service-auth.log</file>
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [auth] [%level] - %logger - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [auth] [%level] - %logger - %message%n%xException
       </pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/service_auth/test/resources/logback-test.xml
+++ b/service_auth/test/resources/logback-test.xml
@@ -24,7 +24,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %coloredLevel - %logger{15} - [%d{yyyy-MM-dd_HH:mm:ss.SSS}] - %message%n%xException
+        %coloredLevel - %logger{15} - [%d{yyyy-MM-dd HH:mm:ss.SSS}] - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_auth/test/resources/logback-test.xml
+++ b/service_auth/test/resources/logback-test.xml
@@ -24,7 +24,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %coloredLevel - %logger{15} - [%d{yyyy-MM-dd HH:mm:ss.SSS}] - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [auth] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_barcode/conf/logback.xml
+++ b/service_barcode/conf/logback.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [barcode] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [barcode] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>
@@ -38,7 +38,7 @@
     <file>logs/service-barcode.log</file>
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [barcode] [%level] - %logger - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [barcode] [%level] - %logger - %message%n%xException
       </pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/service_barcode/test/resources/logback-test.xml
+++ b/service_barcode/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %coloredLevel - %logger{15} - [%d{yyyy-MM-dd HH:mm:ss.SSS}] - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [barcode] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_barcode/test/resources/logback-test.xml
+++ b/service_barcode/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %coloredLevel - %logger{15} - [%d{yyyy-MM-dd_HH:mm:ss.SSS}] - %message%n%xException
+        %coloredLevel - %logger{15} - [%d{yyyy-MM-dd HH:mm:ss.SSS}] - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_geo_location/conf/logback.xml
+++ b/service_geo_location/conf/logback.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [geo_location] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [geo_location] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>
@@ -38,7 +38,7 @@
     <file>logs/service-geolocation.log</file>
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [geo_location] [%level] - %logger - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [geo_location] [%level] - %logger - %message%n%xException
       </pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/service_geo_location/test/resources/logback-test.xml
+++ b/service_geo_location/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [geo_location] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [geo_location] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_storagefacility/app/repositories/dao/StorageTables.scala
+++ b/service_storagefacility/app/repositories/dao/StorageTables.scala
@@ -91,7 +91,17 @@ private[dao] trait StorageTables extends BaseDao with ColumnTypeMappers {
     }.map(_.path).update(path)
   }
 
-  protected[dao] def updatePaths(
+  protected[dao] def updatePartOfAction(
+    id: StorageNodeDatabaseId,
+    partOf: Option[StorageNodeDatabaseId]
+  ): DBIO[Int] = {
+    val filter = storageNodeTable.filter(n =>
+      n.id === id && n.isDeleted === false)
+    val q = for { n <- filter } yield n.isPartOf
+    q.update(partOf)
+  }
+
+  protected[dao] def updatePathsAction(
     oldParent: NodePath,
     newParent: NodePath
   ): DBIO[Int] = {
@@ -106,7 +116,7 @@ private[dao] trait StorageTables extends BaseDao with ColumnTypeMappers {
          UPDATE "MUSARK_STORAGE"."STORAGE_NODE"
          SET "NODE_PATH" = replace("NODE_PATH", ${op}, ${np})
          WHERE "NODE_PATH" LIKE ${pathFilter}
-       """.asUpdate.transactionally
+       """.asUpdate
   }
 
   /**

--- a/service_storagefacility/conf/logback.xml
+++ b/service_storagefacility/conf/logback.xml
@@ -6,7 +6,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [storagefacility] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [storagefacility] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>
@@ -19,7 +19,7 @@
     <file>logs/service-storagefacility.log</file>
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [storagefacility] [%level] - %logger - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [storagefacility] [%level] - %logger - %message%n%xException
       </pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/service_storagefacility/test/resources/logback-test.xml
+++ b/service_storagefacility/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [storagefacility] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [storagefacility] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>

--- a/service_storagefacility/test/services/StorageNodeServiceSpec.scala
+++ b/service_storagefacility/test/services/StorageNodeServiceSpec.scala
@@ -238,7 +238,7 @@ class StorageNodeServiceSpec extends MusitSpecWithAppPerSuite with NodeGenerator
 
       val event = MoveNode.fromCommand(defaultUserId, move).head
 
-      val m = service.moveNode(defaultMuseumId, unit1.id.get, event).futureValue
+      val m = service.moveNodes(defaultMuseumId, building2.id.get, Seq(event)).futureValue
       m.isSuccess mustBe true
 
       mostChildren.map { c =>

--- a/service_thing_aggregate/conf/logback.xml
+++ b/service_thing_aggregate/conf/logback.xml
@@ -6,7 +6,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [thing_aggregate] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [thing_aggregate] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>
@@ -19,7 +19,7 @@
     <file>logs/service-thingaggregate.log</file>
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [thing_aggregate] [%level] - %logger - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [thing_aggregate] [%level] - %logger - %message%n%xException
       </pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/service_thing_aggregate/test/resources/logback-test.xml
+++ b/service_thing_aggregate/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        [%d{yyyy-MM-dd_HH:mm:ss.SSS}] [thing_aggregate] %coloredLevel - %logger{15} - %message%n%xException
+        [%d{yyyy-MM-dd HH:mm:ss.SSS}] [thing_aggregate] %coloredLevel - %logger{15} - %message%n%xException
       </pattern>
     </encoder>
   </appender>


### PR DESCRIPTION
Fixing the same implementation problem for moving nodes as MUSARK-819 did for moving objects.
Moving nodes is slightly more complex due to business rules validations etc. But at least now the two move operations use the same function to perform the actual move.

Also changed formatting of the logging timestamps on @halvoru's request. They should now comply with the ISO date standard. Don't rightly know why there was an `_` character in the format to start with.