### PR TITLE
MUSARK-889: Allows passing in a client name to the login service

### DIFF
--- a/docker/dev/oracle-init.sql
+++ b/docker/dev/oracle-init.sql
@@ -62,6 +62,7 @@ CREATE TABLE MUSARK_AUTH.USER_SESSION (
   last_active      TIMESTAMP WITH TIME ZONE,
   is_logged_in     INTEGER DEFAULT 0 NOT NULL,
   token_expires_in NUMBER(20),
+  client           VARCHAR2(20),
   PRIMARY KEY (session_uuid)
 );
 

--- a/musit-service/src/main/resources/reference.conf
+++ b/musit-service/src/main/resources/reference.conf
@@ -19,4 +19,7 @@ musit {
     clientSecret = ${?DATAPORTEN_CLIENT_SECRET}
     sessionTimeout = 2 hours
   }
+  delphi {
+    callback = "http://127.0.0.1:3030"
+  }
 }

--- a/musit-service/src/main/scala/no/uio/musit/security/AuthResolver.scala
+++ b/musit-service/src/main/scala/no/uio/musit/security/AuthResolver.scala
@@ -65,9 +65,11 @@ trait AuthResolver {
   /**
    * Prepares a new persistent user session
    */
-  def sessionInit()(implicit ec: ExecutionContext): Future[MusitResult[SessionUUID]] = {
+  def sessionInit(
+    client: Option[String]
+  )(implicit ec: ExecutionContext): Future[MusitResult[SessionUUID]] = {
     logger.debug("Initialize a new UserSession with a generated SessionUUID")
-    upsertUserSession(UserSession.prepare())
+    upsertUserSession(UserSession.prepare(client))
   }
 
   def upsertUserSession(

--- a/musit-service/src/main/scala/no/uio/musit/security/AuthTables.scala
+++ b/musit-service/src/main/scala/no/uio/musit/security/AuthTables.scala
@@ -177,6 +177,7 @@ trait AuthTables extends HasDatabaseConfigProvider[JdbcProfile]
     val lastActive = column[Option[DateTime]]("LAST_ACTIVE")
     val isLoggedIn = column[Boolean]("IS_LOGGED_IN")
     val tokenExpiry = column[Option[Long]]("TOKEN_EXPIRES_IN")
+    val client = column[Option[String]]("CLIENT")
 
     val create = (
       uuid: SessionUUID,
@@ -185,7 +186,8 @@ trait AuthTables extends HasDatabaseConfigProvider[JdbcProfile]
       loginTimestamp: Option[DateTime],
       lastActiveTimestamp: Option[DateTime],
       loggedIn: Boolean,
-      expiration: Option[Long]
+      expiration: Option[Long],
+      client: Option[String]
     ) =>
       UserSession(
         uuid = uuid,
@@ -194,7 +196,8 @@ trait AuthTables extends HasDatabaseConfigProvider[JdbcProfile]
         loginTime = loginTimestamp,
         lastActive = lastActiveTimestamp,
         isLoggedIn = loggedIn,
-        tokenExpiry = expiration
+        tokenExpiry = expiration,
+        client = client
       )
 
     val destroy = (us: UserSession) =>
@@ -205,10 +208,11 @@ trait AuthTables extends HasDatabaseConfigProvider[JdbcProfile]
         us.loginTime,
         us.lastActive,
         us.isLoggedIn,
-        us.tokenExpiry
+        us.tokenExpiry,
+        us.client
       ))
 
-    override def * = (uuid, token, userUuid, loginTime, lastActive, isLoggedIn, tokenExpiry) <> (create.tupled, destroy) // scalastyle:ignore
+    override def * = (uuid, token, userUuid, loginTime, lastActive, isLoggedIn, tokenExpiry, client) <> (create.tupled, destroy) // scalastyle:ignore
 
   }
 

--- a/musit-service/src/main/scala/no/uio/musit/security/Authenticator.scala
+++ b/musit-service/src/main/scala/no/uio/musit/security/Authenticator.scala
@@ -20,7 +20,6 @@
 package no.uio.musit.security
 
 import no.uio.musit.MusitResults.MusitResult
-import no.uio.musit.security.oauth2.OAuth2Info
 import play.api.mvc.{Request, Result}
 
 import scala.concurrent.Future
@@ -35,11 +34,14 @@ trait Authenticator {
   /**
    * Starts the OAuth2 authentication process.
    *
+   * @param client A String representing the client performing the request.
    * @param req The current request.
    * @tparam A The type of the request body.
    * @return Either a Result or the active UserSession
    */
-  def authenticate[A]()(implicit req: Request[A]): Future[Either[Result, UserSession]]
+  def authenticate[A](
+    client: Option[String]
+  )(implicit req: Request[A]): Future[Either[Result, UserSession]]
 
   /**
    * Method to "touch" the UserSession whenever a User interacts with a service.
@@ -73,5 +75,12 @@ trait Authenticator {
    * @return Will eventually return a Seq of GroupInfo
    */
   def groups(userInfo: UserInfo): Future[MusitResult[Seq[GroupInfo]]]
+
+}
+
+object Authenticator {
+
+  val ClientWeb = "web"
+  val ClientDelphi = "delphi"
 
 }

--- a/musit-service/src/main/scala/no/uio/musit/security/UserSession.scala
+++ b/musit-service/src/main/scala/no/uio/musit/security/UserSession.scala
@@ -31,7 +31,8 @@ case class UserSession(
     loginTime: Option[DateTime] = None,
     lastActive: Option[DateTime] = None,
     isLoggedIn: Boolean = false,
-    tokenExpiry: Option[Long] = None
+    tokenExpiry: Option[Long] = None,
+    client: Option[String] = None
 ) {
 
   def touch(timeoutMillis: Long): UserSession = {
@@ -62,6 +63,7 @@ case class UserSession(
 
 object UserSession {
 
-  def prepare(): UserSession = UserSession(SessionUUID.generate())
+  def prepare(client: Option[String]): UserSession =
+    UserSession(uuid = SessionUUID.generate(), client = client.map(_.toLowerCase))
 
 }

--- a/musit-service/src/main/scala/no/uio/musit/security/dataporten/DatabaseAuthResolver.scala
+++ b/musit-service/src/main/scala/no/uio/musit/security/dataporten/DatabaseAuthResolver.scala
@@ -100,9 +100,7 @@ class DatabaseAuthResolver @Inject() (
   override def userSession(
     sessionUUID: SessionUUID
   )(implicit ec: ExecutionContext): Future[MusitResult[Option[UserSession]]] = {
-    val query = usrSessionTable.filter { us =>
-      us.uuid === sessionUUID
-    }
+    val query = usrSessionTable.filter(_.uuid === sessionUUID)
 
     db.run(query.result.headOption).map(MusitSuccess.apply).recover {
       case NonFatal(ex) =>

--- a/musit-service/src/main/scala/no/uio/musit/security/fake/FakeAuthenticator.scala
+++ b/musit-service/src/main/scala/no/uio/musit/security/fake/FakeAuthenticator.scala
@@ -116,11 +116,12 @@ class FakeAuthenticator extends Authenticator {
    * Fake authenticate implementation that "logs" in a user based on the data
    * found in the fake_security.json
    *
+   * @param client the client making the auth request
    * @param req The current request.
    * @tparam A The type of the request body.
    * @return Either a Result or the active UserSession
    */
-  override def authenticate[A]()(
+  override def authenticate[A](client: Option[String])(
     implicit
     req: Request[A]
   ): Future[Either[Result, UserSession]] = Future.successful {

--- a/musit-service/src/test/resources/evolutions/test/1.sql
+++ b/musit-service/src/test/resources/evolutions/test/1.sql
@@ -54,6 +54,7 @@ CREATE TABLE MUSARK_AUTH.USER_SESSION (
   last_active      TIMESTAMP, -- WITH TIME ZONE,
   is_logged_in     INTEGER DEFAULT 0 NOT NULL,
   token_expires_in NUMBER(20),
+  client           VARCHAR2(20),
   PRIMARY KEY (session_uuid)
 );
 

--- a/musit-service/src/test/scala/no/uio/musit/security/dataporten/DataportenAuthenticatorSpec.scala
+++ b/musit-service/src/test/scala/no/uio/musit/security/dataporten/DataportenAuthenticatorSpec.scala
@@ -22,15 +22,14 @@ package no.uio.musit.security.dataporten
 import java.util.UUID
 
 import no.uio.musit.models.{ActorId, Email}
-import no.uio.musit.security.{BearerToken, SessionUUID}
-import no.uio.musit.security.oauth2.OAuth2Info
+import no.uio.musit.security.{Authenticator, BearerToken, SessionUUID}
 import no.uio.musit.test.MusitSpecWithAppPerSuite
 import org.scalamock.scalatest.MockFactory
 import play.api.Configuration
 import play.api.http.{DefaultWriteables, Writeable}
 import play.api.libs.json.Json
 import play.api.libs.ws.{WSAPI, WSRequest, WSResponse}
-import play.api.mvc.{Result, Results}
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
@@ -66,7 +65,7 @@ class DataportenAuthenticatorSpec extends MusitSpecWithAppPerSuite
 
       implicit val fakeRequest = FakeRequest("GET", "/authenticate")
 
-      val futRes = authenticator.authenticate()
+      val futRes = authenticator.authenticate(Some(Authenticator.ClientWeb))
       val res = futRes.futureValue
       res.isLeft mustBe true
       res.left.get mustBe a[Result]
@@ -128,7 +127,7 @@ class DataportenAuthenticatorSpec extends MusitSpecWithAppPerSuite
         )
       ).atLeastTwice()
 
-      val futRes = authenticator.authenticate()
+      val futRes = authenticator.authenticate(Some(Authenticator.ClientWeb))
 
       val res = futRes.futureValue
       res.isRight mustBe true

--- a/service_auth/conf/application.conf
+++ b/service_auth/conf/application.conf
@@ -54,4 +54,3 @@ slick {
   }
 }
 
-actor.detailsUrl = "http://actor:7070/v1/person/details"

--- a/service_auth/conf/evolutions/default/1.sql
+++ b/service_auth/conf/evolutions/default/1.sql
@@ -54,6 +54,7 @@ CREATE TABLE MUSARK_AUTH.USER_SESSION (
   last_active      TIMESTAMP WITH TIME ZONE,
   is_logged_in     INTEGER DEFAULT 0 NOT NULL,
   token_expires_in NUMBER(20),
+  client           VARCHAR2(20),
   PRIMARY KEY (session_uuid)
 );
 

--- a/service_auth/conf/routes
+++ b/service_auth/conf/routes
@@ -26,7 +26,7 @@ POST        /web/groups/:groupId/:email/collection/:colId/revoke        controll
 
 
 # REST endpoints
-GET         /rest/authenticate                                          controllers.rest.AuthenticationController.authenticate
+GET         /rest/authenticate                                          controllers.rest.AuthenticationController.authenticate(client: Option[String])
 GET         /rest/logout                                                controllers.rest.AuthenticationController.logout
 GET         /rest/museums                                               controllers.rest.MuseumController.listMuseums
 POST        /rest/museum/:museumId/group                                controllers.rest.GroupController.addGroup(museumId: Int)


### PR DESCRIPTION
This is specifically intended to be used for the Delphi applications, that require a different redirect result than the normal web-client. In the future this can in theory be extended to be used with even more clients. Each requiring separate handling for the redirect.