### PR TITLE
Run tests from intellij

### DIFF
--- a/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
+++ b/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
@@ -4,7 +4,17 @@ import play.api.inject.guice.GuiceApplicationBuilder
 
 trait MusitFakeApplication extends TestConfigs {
 
-  def createApplication() =
+  def createApplication() = {
+    if (notExecutedFromSbt) {
+      setProperty("config.file", "/application.test.conf")
+      setProperty("logger.file", "/logback-test.xml")
+    }
     new GuiceApplicationBuilder().configure(slickWithInMemoryH2()).build()
+  }
+
+  private def notExecutedFromSbt = System.getProperty("config.file") == null
+
+  private def setProperty(p: String, r: String): Unit =
+    System.setProperty(p, this.getClass.getResource(r).getPath)
 
 }

--- a/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
+++ b/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
@@ -6,18 +6,17 @@ trait MusitFakeApplication extends TestConfigs {
 
   def createApplication() = {
     if (notExecutedFromPlayProject) {
-      setProperty("config.file", "/application.test.conf")
-      setProperty("logger.file", "/logback-test.xml")
+      setPropertyIfFileExists("config.file", "/application.test.conf")
+      setPropertyIfFileExists("logger.file", "/logback-test.xml")
     }
     new GuiceApplicationBuilder().configure(slickWithInMemoryH2()).build()
   }
 
   private def notExecutedFromPlayProject =
-    System.getProperty("config.file") == null
+    sys.props.get("config.file").isEmpty
 
-  private def setProperty(p: String, r: String): Unit = {
-    val resource = this.getClass.getResource(r)
-    if (resource != null) System.setProperty(p, resource.getPath)
-  }
+  private def setPropertyIfFileExists(p: String, r: String): Unit =
+    Option(this.getClass.getResource(r))
+      .foreach(res => System.setProperty(p, res.getPath))
 
 }

--- a/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
+++ b/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
@@ -5,16 +5,19 @@ import play.api.inject.guice.GuiceApplicationBuilder
 trait MusitFakeApplication extends TestConfigs {
 
   def createApplication() = {
-    if (notExecutedFromSbt) {
+    if (notExecutedFromPlayProject) {
       setProperty("config.file", "/application.test.conf")
       setProperty("logger.file", "/logback-test.xml")
     }
     new GuiceApplicationBuilder().configure(slickWithInMemoryH2()).build()
   }
 
-  private def notExecutedFromSbt = System.getProperty("config.file") == null
+  private def notExecutedFromPlayProject =
+    System.getProperty("config.file") == null
 
-  private def setProperty(p: String, r: String): Unit =
-    System.setProperty(p, this.getClass.getResource(r).getPath)
+  private def setProperty(p: String, r: String): Unit = {
+    val resource = this.getClass.getResource(r)
+    if (resource != null) System.setProperty(p, resource.getPath)
+  }
 
 }

--- a/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
+++ b/musit-test/src/main/scala/no/uio/musit/test/MusitFakeApplication.scala
@@ -1,22 +1,3 @@
-/*
- * MUSIT is a museum database to archive natural and cultural history data.
- * Copyright (C) 2016  MUSIT Norway, part of www.uio.no (University of Oslo)
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License,
- * or any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
-
 package no.uio.musit.test
 
 import play.api.inject.guice.GuiceApplicationBuilder


### PR DESCRIPTION
Intellij Idea doesn't read the sbt config when running tests
from the editor. All tests that's not depending on configuration
loaded from the application.test.conf does work without any
modification. This is a workaround that enables us to run all the tests
trough Idea in a way that doesn't conflict with how sbt setup the test
environment.

https://www.playframework.com/documentation/2.5.x/ProductionConfiguration